### PR TITLE
BlogCardコンポーネントを宣言するときに、アロー演算子を使用する

### DIFF
--- a/src/components/page/Index/BlogCard.tsx
+++ b/src/components/page/Index/BlogCard.tsx
@@ -3,7 +3,7 @@ import styles from "./BlogCard.module.css";
 import RelativeDate from "../../date/RelativeDate";
 import "dayjs/locale/ja";
 
-export default function BlogCard({ blog }) {
+const BlogCard = ({ blog }) => {
   return (
     <div className={styles.card}>
       <Link href={`/blog/${blog.id}`}>
@@ -18,4 +18,6 @@ export default function BlogCard({ blog }) {
       </Link>
     </div>
   );
-}
+};
+
+export default BlogCard;


### PR DESCRIPTION
reactではコンポーネントを作成するときはアロー演算子を使用するのが一般的なので、fanctionからアロー演算子に書き換え