### PR TITLE
ファイル名を大文字始まりから小文字始まりに変更

### DIFF
--- a/src/infra/microCMS/schema/category.ts
+++ b/src/infra/microCMS/schema/category.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  id: string;
+  name: string;
+};

--- a/src/infra/microCMS/schema/categoryArray.ts
+++ b/src/infra/microCMS/schema/categoryArray.ts
@@ -1,0 +1,5 @@
+import { Category } from "./category";
+
+export type CategoryArray = {
+  category: Category[];
+};


### PR DESCRIPTION
型定義のファイル名が小文字始まりと大文字始まりのファイルがあったので、小文字始まりに統一する