### PR TITLE
tagページにクエリパラメータがある場合の処理を修正

### DIFF
--- a/src/commons/tag/TagButton/TagButton.tsx
+++ b/src/commons/tag/TagButton/TagButton.tsx
@@ -2,17 +2,23 @@ import Link from "next/link";
 import styles from "./TagButton.module.css";
 import { NextPage } from "next";
 import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
+import { useRouter } from "next/router";
 
 export type Props = {
   category: CategoryList;
 };
 
 const TagButton: NextPage<Props> = ({ category }) => {
+  const router = useRouter();
   return (
     <>
       {category.slice().map((category) => (
         <Link
-          href={`/article/recent/tag/?id=${category.id}`}
+          href={
+            router.pathname === "/article/recent/tag"
+              ? `/article/recent/tag/?id=${category.id}`
+              : `/article/recent/tag`
+          }
           className={styles.tag}
           key={category.name}
         >

--- a/src/commons/tag/TagButton/TagMain/TagMain.tsx
+++ b/src/commons/tag/TagButton/TagMain/TagMain.tsx
@@ -7,6 +7,7 @@ import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { NextPage } from "next";
 import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
 import TagFilter from "@/features/blog/article/components/TagFilter/TagFilter";
+import Link from "next/link";
 
 type Props = {
   category: CategoryList;
@@ -14,16 +15,20 @@ type Props = {
 };
 
 const TagMain: NextPage<Props> = ({ category, blogCategoryList }) => {
-  console.log(useRouter().query["id"]);
   return (
     <Commonlayout>
       <div className={styles.container}>
-        <div className={styles.title}>タグページ</div>
+        <Link href={""} className={styles.title}>
+          タグページ
+        </Link>
         <div className={styles.tagButton}>
           <TagButton category={category} />
         </div>
         {useRouter().query["id"] ? (
-          <TagFilter categoryID={`${useRouter().query["id"]}`} />
+          <TagFilter
+            queryID={`${useRouter().query["id"]}`}
+            blogCategoryList={blogCategoryList}
+          />
         ) : (
           <BlogListByCategories blogCategoryList={blogCategoryList} />
         )}

--- a/src/commons/tag/TagButton/TagMain/TagMain.tsx
+++ b/src/commons/tag/TagButton/TagMain/TagMain.tsx
@@ -6,6 +6,7 @@ import BlogListByCategories from "@/features/blog/article/components/BlogListByC
 import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { NextPage } from "next";
 import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
+import TagFilter from "@/features/blog/article/components/TagFilter/TagFilter";
 
 type Props = {
   category: CategoryList;
@@ -13,6 +14,7 @@ type Props = {
 };
 
 const TagMain: NextPage<Props> = ({ category, blogCategoryList }) => {
+  console.log(useRouter().query["id"]);
   return (
     <Commonlayout>
       <div className={styles.container}>
@@ -21,7 +23,7 @@ const TagMain: NextPage<Props> = ({ category, blogCategoryList }) => {
           <TagButton category={category} />
         </div>
         {useRouter().query["id"] ? (
-          <div>filter</div> // クエリにidがある場合の処理をかく
+          <TagFilter categoryID={`${useRouter().query["id"]}`} />
         ) : (
           <BlogListByCategories blogCategoryList={blogCategoryList} />
         )}

--- a/src/features/blog/article/components/TagFilter/TagFilter.tsx
+++ b/src/features/blog/article/components/TagFilter/TagFilter.tsx
@@ -1,0 +1,10 @@
+import { NextPage } from "next";
+import BlogListByCategories from "../BlogListByCategories/BlogListByCategories";
+
+type Props = {};
+
+const TagFilter: NextPage<Props> = ({ categoryID }) => {
+  return <BlogListByCategories blogCategoryList={blogCategoryList} />;
+};
+
+export default TagFilter;

--- a/src/features/blog/article/components/TagFilter/TagFilter.tsx
+++ b/src/features/blog/article/components/TagFilter/TagFilter.tsx
@@ -1,10 +1,28 @@
 import { NextPage } from "next";
-import BlogListByCategories from "../BlogListByCategories/BlogListByCategories";
+import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
+import BlogCard from "@/commons/blog/BlogCard/BlogCard";
 
-type Props = {};
-
-const TagFilter: NextPage<Props> = ({ categoryID }) => {
-  return <BlogListByCategories blogCategoryList={blogCategoryList} />;
+type Props = {
+  queryID: string;
+  blogCategoryList: BlogCategoryList;
 };
 
+const TagFilter: NextPage<Props> = ({ queryID, blogCategoryList }) => {
+  return (
+    <>
+      {blogCategoryList.map((blogCategory) => (
+        <>
+          {blogCategory.id == queryID ? (
+            <>
+              <div>{blogCategory.name}</div>
+              {blogCategory.blogList.contents.map((blogList) => (
+                <BlogCard key={blogCategory.id} blog={blogList} />
+              ))}
+            </>
+          ) : null}
+        </>
+      ))}
+    </>
+  );
+};
 export default TagFilter;

--- a/src/pages/article/recent/tag.tsx
+++ b/src/pages/article/recent/tag.tsx
@@ -48,33 +48,3 @@ const ArticleRecentTagPage: NextPage<Props> = ({
   return <TagMain category={category} blogCategoryList={blogCategoryList} />;
 };
 export default ArticleRecentTagPage;
-
-{
-  /* <div key={category.id}>
-<Link
-  href={`./tag/?id=${category.id}`}
-  className={styles.tag}
-  key={category.name}
->
-  {category.name}
-</Link>
-
-{blog.categories ? <div>tag</div> : <div>none</div>}
-</div> */
-}
-
-//  "blog.map((blog) => blogContents({ blog }))"
-// export function BlogListGroup({ blog, category }) {
-//   return blog.map((blog) => (
-//     <div>
-//       {blog.categories.length > 0 ? (
-//         blogContents({ blog })
-//       ) : (
-//         <>
-//           <div>タグ未設定</div>
-//           {blogContents({ blog })}
-//         </>
-//       )}
-//     </div>
-//   ));
-// }


### PR DESCRIPTION
今までクエリパラメータがある場合の処理を仮置きしていたので修正する
クエリパラメータのidと一致するカテゴリータグがついているブログを表示する処理を追加する