### PR TITLE
修正：tag.tsxで取得したデータをPlainTextに変換して返す

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Commonlayout"
+    ]
+}

--- a/src/commons/blog/BlogCard/BlogCard.tsx
+++ b/src/commons/blog/BlogCard/BlogCard.tsx
@@ -3,8 +3,8 @@ import styles from "./BlogCard.module.css";
 import RelativeDate from "../../date/RelativeDate/RelativeDate";
 import "dayjs/locale/ja";
 import { NextPage } from "next";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { BlogWithPlainText } from "@/infra/microCMS/schema/Blog/blogWithPlainText";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   blogsWithPlainText: BlogWithPlainText;

--- a/src/commons/tag/TagButton/TagMain/TagMain.tsx
+++ b/src/commons/tag/TagButton/TagMain/TagMain.tsx
@@ -3,11 +3,11 @@ import styles from "./TagMain.module.css";
 import TagButton from "../TagButton";
 import { useRouter } from "next/router";
 import BlogListByCategories from "@/features/blog/article/components/BlogListByCategories/BlogListByCategories";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { NextPage } from "next";
-import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
 import TagFilter from "@/features/blog/article/components/TagFilter/TagFilter";
 import Link from "next/link";
+import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   category: CategoryList;

--- a/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
+++ b/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
@@ -5,13 +5,13 @@ import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCateg
 import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
-  blogCategoryList: BlogCategoryList;
   category: CategoryList;
+  blogCategoryList: BlogCategoryList;
 };
 
 const BlogListByCategories: NextPage<Props> = ({
-  blogCategoryList,
   category,
+  blogCategoryList,
 }) => {
   return (
     <div className={styles.blogGroup}>
@@ -22,9 +22,16 @@ const BlogListByCategories: NextPage<Props> = ({
               <span className={styles.tagName}>{blogCategory.name}</span>
             </div>
             <div className={styles.blogList}>
-              {blogCategory.blogList.contents.map((blog) => (
-                <BlogCard key={blog.id} blog={blog} category={category} />
-              ))}
+              {blogCategory.blogWithPlainTextList.map((blog) => {
+                console.log(blog);
+                return (
+                  <BlogCard
+                    key={blog.id}
+                    blogsWithPlainText={blog}
+                    category={category}
+                  />
+                );
+              })}
             </div>
           </div>
         </>

--- a/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
+++ b/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
@@ -1,8 +1,8 @@
 import BlogCard from "@/commons/blog/BlogCard/BlogCard";
-import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
 import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { NextPage } from "next";
 import styles from "@/features/blog/article/components/BlogListByCategories/BlogListCategories.module.css";
+import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
 
 type Props = {
   blogCategoryList: BlogCategoryList;

--- a/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
+++ b/src/features/blog/article/components/BlogListByCategories/BlogListByCategories.tsx
@@ -1,8 +1,8 @@
 import BlogCard from "@/commons/blog/BlogCard/BlogCard";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { NextPage } from "next";
 import styles from "@/features/blog/article/components/BlogListByCategories/BlogListCategories.module.css";
 import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   blogCategoryList: BlogCategoryList;

--- a/src/features/blog/article/components/TagFilter/TagFilter.tsx
+++ b/src/features/blog/article/components/TagFilter/TagFilter.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from "next";
-import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
 import BlogCard from "@/commons/blog/BlogCard/BlogCard";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import styles from "@/features/blog/article/components/TagFilter/TagFilter.module.css";
+import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   queryID: string;
@@ -23,10 +23,10 @@ const TagFilter: NextPage<Props> = ({
             <>
               <div className={styles.tagName}>{blogCategory.name}</div>
               <div className={styles.blogList}>
-                {blogCategory.blogList.contents.map((blogList) => (
+                {blogCategory.blogWithPlainTextList.map((blogList) => (
                   <BlogCard
                     key={blogCategory.id}
-                    blog={blogList}
+                    blogsWithPlainText={blogList}
                     category={category}
                   />
                 ))}

--- a/src/features/blog/home/components/HomePageMain/HomePageMain.tsx
+++ b/src/features/blog/home/components/HomePageMain/HomePageMain.tsx
@@ -2,8 +2,8 @@ import BlogCard from "@/commons/blog/BlogCard/BlogCard";
 import styles from "./HomePageMain.module.css";
 import CommonLayout from "@/commons/layout/Layout/CommonLayout";
 import { NextPage } from "next";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { BlogWithPlainTextList } from "@/infra/microCMS/schema/Blog/blogWithPlainText";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   blogsWithPlainText: BlogWithPlainTextList;

--- a/src/infra/microCMS/schema/Blog/blog.ts
+++ b/src/infra/microCMS/schema/Blog/blog.ts
@@ -10,5 +10,3 @@ export type Blog = {
   title: string;
   body: string;
 };
-
-export type BlogList = Blog[];

--- a/src/infra/microCMS/schema/Blog/blog.ts
+++ b/src/infra/microCMS/schema/Blog/blog.ts
@@ -10,3 +10,5 @@ export type Blog = {
   title: string;
   body: string;
 };
+
+export type BlogList = Blog[];

--- a/src/infra/microCMS/schema/Blog/blogList.ts
+++ b/src/infra/microCMS/schema/Blog/blogList.ts
@@ -1,3 +1,0 @@
-import { Blog } from "./blog";
-
-export type BlogList = Blog[];

--- a/src/infra/microCMS/schema/Blog/blogList.ts
+++ b/src/infra/microCMS/schema/Blog/blogList.ts
@@ -1,0 +1,3 @@
+import { Blog } from "./blog";
+
+export type BlogList = Blog[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -7,3 +7,4 @@ export type BlogCategory = {
     contents: BlogList;
   };
 };
+export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -1,9 +1,10 @@
-import { BlogList } from "../Blog/blogList";
+import { BlogList } from "../Blog/blog";
 
 export type BlogCategory = {
-  name: string;
   id: string;
+  name: string;
   blogList: {
     contents: BlogList;
   };
 };
+export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -3,9 +3,6 @@ import { BlogWithPlainTextList } from "../Blog/blogWithPlainText";
 export type BlogCategory = {
   name: string;
   id: string;
-  blogWithPlainTextList: {
-    contents: BlogWithPlainTextList;
-    // contents: BlogList;
-  };
+  blogWithPlainTextList:  BlogWithPlainTextList;
 };
 export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -3,7 +3,7 @@ import { BlogWithPlainTextList } from "../Blog/blogWithPlainText";
 export type BlogCategory = {
   name: string;
   id: string;
-  blogLBlogWithPlainTextList: {
+  blogWithPlainTextList: {
     contents: BlogWithPlainTextList;
     // contents: BlogList;
   };

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -1,10 +1,9 @@
-import { BlogList } from "../Blog/blog";
+import { BlogList } from "../Blog/blogList";
 
 export type BlogCategory = {
-  id: string;
   name: string;
+  id: string;
   blogList: {
     contents: BlogList;
   };
 };
-export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategory.ts
@@ -1,10 +1,11 @@
-import { BlogList } from "../Blog/blogList";
+import { BlogWithPlainTextList } from "../Blog/blogWithPlainText";
 
 export type BlogCategory = {
   name: string;
   id: string;
-  blogList: {
-    contents: BlogList;
+  blogLBlogWithPlainTextList: {
+    contents: BlogWithPlainTextList;
+    // contents: BlogList;
   };
 };
 export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategoryList.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategoryList.ts
@@ -1,0 +1,3 @@
+import { BlogCategory } from "./blogCategory";
+
+export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/BlogCategory/blogCategoryList.ts
+++ b/src/infra/microCMS/schema/BlogCategory/blogCategoryList.ts
@@ -1,3 +1,0 @@
-import { BlogCategory } from "./blogCategory";
-
-export type BlogCategoryList = BlogCategory[];

--- a/src/infra/microCMS/schema/Category/category.ts
+++ b/src/infra/microCMS/schema/Category/category.ts
@@ -2,3 +2,4 @@ export type Category = {
   id: string;
   name: string;
 };
+export type CategoryList = Category[];

--- a/src/infra/microCMS/schema/Category/categoryList.ts
+++ b/src/infra/microCMS/schema/Category/categoryList.ts
@@ -1,3 +1,0 @@
-import { Category } from "./category";
-
-export type CategoryList = Category[];

--- a/src/pages/article/recent/tag.tsx
+++ b/src/pages/article/recent/tag.tsx
@@ -1,4 +1,3 @@
-import { Blog } from "@/infra/microCMS/schema/Blog/blog";
 import TagMain from "@/commons/tag/TagButton/TagMain/TagMain";
 import { GetStaticProps, NextPage } from "next";
 import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
@@ -7,9 +6,8 @@ import { getBlogList } from "@/infra/microCMS/repositories/blog";
 import { getCategoriesList } from "@/infra/microCMS/repositories/categories";
 
 type Props = {
-  blog: Blog;
-  category: CategoryList;
   blogCategoryList: BlogCategoryList;
+  category: CategoryList;
 };
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/src/pages/article/recent/tag.tsx
+++ b/src/pages/article/recent/tag.tsx
@@ -1,9 +1,9 @@
 import TagMain from "@/commons/tag/TagButton/TagMain/TagMain";
 import { GetStaticProps, NextPage } from "next";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
-import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategoryList";
 import { getBlogList } from "@/infra/microCMS/repositories/blog";
 import { getCategoriesList } from "@/infra/microCMS/repositories/categories";
+import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   blogCategoryList: BlogCategoryList;

--- a/src/pages/article/recent/tag.tsx
+++ b/src/pages/article/recent/tag.tsx
@@ -4,6 +4,7 @@ import { getBlogList } from "@/infra/microCMS/repositories/blog";
 import { getCategoriesList } from "@/infra/microCMS/repositories/categories";
 import { BlogCategoryList } from "@/infra/microCMS/schema/BlogCategory/blogCategory";
 import { CategoryList } from "@/infra/microCMS/schema/Category/category";
+import * as cheerio from "cheerio";
 
 type Props = {
   blogCategoryList: BlogCategoryList;
@@ -16,19 +17,37 @@ export const getStaticProps: GetStaticProps = async () => {
     return category.id;
   });
 
-  const promises = categoryIds.map((categoryId) => {
-    return getBlogList({
-      queries: { limit: 10, filters: `categories[contains]${categoryId}` },
-    });
-  });
-  const blogListByCategory = await Promise.all(promises);
+  const blogListByCategory = await Promise.all(
+    categoryIds.map((categoryId) =>
+      getBlogList({
+        queries: { limit: 10, filters: `categories[contains]${categoryId}` },
+      })
+    )
+  );
+
+  const blogWithPlainTextList = blogListByCategory.map((article) => ({
+    ...article,
+    contents: article.contents.map((blog) => {
+      const $ = cheerio.load(blog.body);
+      $("br").replaceWith("\n");
+      $("h1, h2, h3, h4, h5, h6, p, li, blockquote").append("\n");
+      const plainText = $.text().trim().slice(0, 150);
+
+      return {
+        ...blog,
+        plainTextBody: plainText,
+      };
+    }),
+  }));
+
   const blogCategoryList = categoryData.contents.map((category, index) => {
     return {
       id: category.id,
       name: category.name,
-      blogList: blogListByCategory[index],
+      blogWithPlainTextList: blogWithPlainTextList[index].contents,
     };
   });
+
   return {
     props: {
       category: categoryData.contents,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import HomeMain from "@/features/blog/home/components/HomePageMain/HomePageMain";
 import { GetStaticProps, NextPage } from "next";
-import { CategoryList } from "@/infra/microCMS/schema/Category/categoryList";
 import { getBlogList } from "@/infra/microCMS/repositories/blog";
 import { getCategoriesList } from "@/infra/microCMS/repositories/categories";
 import * as cheerio from "cheerio";
 import { BlogWithPlainTextList } from "@/infra/microCMS/schema/Blog/blogWithPlainText";
+import { CategoryList } from "@/infra/microCMS/schema/Category/category";
 
 type Props = {
   blogsWithPlainText: BlogWithPlainTextList;


### PR DESCRIPTION
## 概要
BlogCard.tsxの変更によりcategoryページでエラーが発生した

### 変更内容
- BlogCategory型のBlog型をBlogWithPlainText型に変更
- tag.tsx内で取得したコンテンツをPlainTextに変更する処理を追加
- それに伴ってcategoryページで使用されているコンポーネントの修正
- PlainTextに変換する処理の切り出し