### PR TITLE
[fix] 記事ページでmicroCMSで記入した改行が反映されない問題・軽微なスタイル修正

### DIFF
--- a/src/features/article/components/ArticlePageMain/ArticlePage.module.scss
+++ b/src/features/article/components/ArticlePageMain/ArticlePage.module.scss
@@ -34,7 +34,7 @@
       max-width: 800px;
 
       .pageNav {
-        margin: 125px 0;
+        margin: 75px 0 300px 0;
       }
 
       .backLink {
@@ -42,8 +42,7 @@
         text-decoration: none;
         font-size: 0.8em;
         font-weight: bold;
-        margin-top: 5em;
-        margin-bottom: 15em;
+        margin: 200px 0 300px;
       }
 
       .backLink:hover {
@@ -67,22 +66,31 @@
   }
 }
 
-.article p:empty {
-  display: block;
-  margin-top: 1em; /* 上部に余白を追加 */
-  margin-bottom: 1em; /* 下部に余白を追加 */
-  visibility: hidden; /* 空の段落を非表示にして余白だけ反映 */
-}
-
 .article {
   border-radius: 10px;
   background-color: #fbfbfb;
-  padding: 20px 20px 100px 20px;
+  padding: 20px 20px 40px 20px;
   font-size: variables.$font-size-base;
   line-height: 1.5em;
   font-family: "Noto Sans JP", sans-serif;
   color: #000000;
   overflow-wrap: break-word;
+
+  /* 空の<p>タグに改行を適用 */
+  p:empty {
+    display: block;
+    height: 1em;
+    margin: 1em 0;
+    min-height: 1em;
+  }
+
+  /* 空白のみの<p>タグにも対応 */
+  p:blank {
+    display: block;
+    height: 1em;
+    margin: 1em 0;
+    min-height: 1em;
+  }
 
   /* margin-bottom: 5em; */
 
@@ -141,7 +149,7 @@
   p:has(span[class="callout"]) {
     background-color: #f6ffe6;
     padding: 30px;
-    margin: 30px 0;
+    margin: 10px 0;
     border-radius: 5px;
     border: 1px solid #c2ea7d;
   }

--- a/src/features/article/components/ArticlePageMain/_variables.scss
+++ b/src/features/article/components/ArticlePageMain/_variables.scss
@@ -1,6 +1,6 @@
-$font-size-xx-large: 28px;
-$font-size-x-large: 23px;
-$font-size-large: 18px;
+$font-size-xx-large: 23px;
+$font-size-x-large: 20px;
+$font-size-large: 16px;
 $font-size-base: 14px;
 $font-size-small: 12px;
 $font-size-x-small: 10px;
@@ -15,19 +15,26 @@ $line-height-x-small: 10px;
 $list-style-type-ul: disc;
 $list-style-type-ol: decimal;
 
+$margin-xx-large: 20px;
+$margin-x-large: 15px;
+$margin-large: 13px;
+
 @mixin h1 {
   font-size: $font-size-xx-large;
   line-height: $line-height-xx-large;
+  margin: $margin-xx-large 0;
 }
 
 @mixin h2 {
   font-size: $font-size-x-large;
   line-height: $line-height-x-large;
+  margin: $margin-x-large 0;
 }
 
 @mixin h3 {
   font-size: $font-size-large;
   line-height: $line-height-large;
+  margin: $margin-large 0;
 }
 
 @mixin h4 {


### PR DESCRIPTION
# 概要
- microCMS上で記入した改行は空の`<p>`となって取得される
  - 空の`<p>`が適用されず、改行が反映されていない

- 他、記事の軽微な修正


## 変更内容
- `p:empty`についていた`visibility: hidden;`を削除
- ページネーションと見出し（`h1`,`h2`,`h3`）のmarginの修正
