### PR TITLE
[fix] tagを押したときに存在しないパスへと遷移する問題

### DIFF
--- a/src/commons/tag/components/TagButton/TagButton.tsx
+++ b/src/commons/tag/components/TagButton/TagButton.tsx
@@ -12,7 +12,6 @@ const TagButton: NextPage<Props> = ({ category }) => {
     <div className={styles.tagButtonRoot}>
       {category.slice().map((category) => (
         <Link
-          // TODO: マジックナンバー切り分け
           href={`/article/recent/category?id=${category.id}`}
           className={styles.tag}
           key={category.name}


### PR DESCRIPTION
# 概要
- 前にappRouterに変更しようとした時の残骸が残っていた
- pathの取得方法がpagesとapprouterでは異なるため、正しく遷移しなくなっていた

# 変更内容
- `TagButton.tsx`の`<Link>`コンポーネントの`href`を修正