### PR TITLE
[ref] ブログ本文のスタイルの修正,Tailwindへの移行検討

### DIFF
--- a/src/features/blog/components/BlogDetail/BlogDetail.module.scss
+++ b/src/features/blog/components/BlogDetail/BlogDetail.module.scss
@@ -30,8 +30,8 @@
   h4,
   h5 {
     font-weight: bold;
-    margin-top: 20px;
-    margin-bottom: 0.5em;
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
   }
 
   h1 {
@@ -52,8 +52,8 @@
 
   ul,
   ol {
-    padding: 0 0 0 16px;
-    margin: 24px 0;
+    padding: 0 0 0 1rem;
+    margin: 1.5rem 0;
   }
 
   ul {

--- a/src/features/blog/components/BlogDetail/BlogDetail.module.scss
+++ b/src/features/blog/components/BlogDetail/BlogDetail.module.scss
@@ -1,9 +1,6 @@
 @use "variables";
 
 .article {
-  border-radius: 10px;
-  background-color: #fbfbfb;
-  padding: 20px 20px 40px 20px;
   font-size: variables.$font-size-base;
   line-height: 1.5em;
   font-family: "Noto Sans JP", sans-serif;
@@ -25,8 +22,6 @@
     margin: 1em 0;
     min-height: 1em;
   }
-
-  /* margin-bottom: 5em; */
 
   /* 見出し */
   h1,
@@ -83,7 +78,7 @@
   p:has(span[class="callout"]) {
     background-color: #f6ffe6;
     padding: 30px;
-    margin: 10px 0;
+    margin: 1.25em 0;
     border-radius: 5px;
     border: 1px solid #c2ea7d;
   }
@@ -102,11 +97,12 @@
     }
   }
 
-  /* ================================
-     Figure
-  ================================ */
+  /* Figure */
   figure {
-    margin: 1em;
+    margin: 1.25em 0;
+    img {
+      border-radius: 5px;
+    }
   }
 
   /* ================================
@@ -170,19 +166,5 @@
       font-family: "Fira Code";
       line-height: 1em;
     }
-  }
-
-  /* 言語ラベル */
-  div[data-filename="callout"] pre code::before {
-    font-size: 0.75rem;
-    font-weight: bold;
-    color: #ffffff;
-    background: #4a4a4a;
-    padding: 2px 8px;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-    position: absolute;
-    top: 0;
-    left: 0;
   }
 }

--- a/src/features/blog/components/BlogDetail/BlogDetail.tsx
+++ b/src/features/blog/components/BlogDetail/BlogDetail.tsx
@@ -1,3 +1,4 @@
+import style from "./BlogDetail.module.scss";
 import Link from "next/link";
 import { Blog } from "@/libs/schema/contents/Blog/blog";
 import { Category } from "@/libs/schema/contents/Category/category";
@@ -28,13 +29,15 @@ const BlogDetail = ({ blog, category, blogNavigation }: Props) => {
         </div>
       </div>
       <div className="flex justify-center gap-4">
-        <div className="w-full min-w-0 lg:max-w-4xl">
-          <div
-            className="article"
-            dangerouslySetInnerHTML={{
-              __html: blog.body,
-            }}
-          />
+        <div className="min-h-1.5 w-full lg:max-w-4xl">
+          <div className="min-h-36 rounded-lg bg-zinc-50 p-5">
+            <div
+              className={style.article}
+              dangerouslySetInnerHTML={{
+                __html: blog.body,
+              }}
+            />
+          </div>
           <div className="my-40">
             <PageNav blogNavigation={blogNavigation} />
           </div>

--- a/src/features/blog/components/BlogDetail/BlogDetail.tsx
+++ b/src/features/blog/components/BlogDetail/BlogDetail.tsx
@@ -29,7 +29,7 @@ const BlogDetail = ({ blog, category, blogNavigation }: Props) => {
         </div>
       </div>
       <div className="flex justify-center gap-4">
-        <div className="min-h-1.5 w-full lg:max-w-4xl">
+        <div className="w-full min-w-0 lg:max-w-4xl">
           <div className="min-h-36 rounded-lg bg-zinc-50 p-5">
             <div
               className={style.article}


### PR DESCRIPTION
## 対象
`BlogDitail`コンポーネントで読み込まれるブログ本文のスタイル
HTMLタグを含んだ文字列として渡される
  ```jsx
 <div
  className={style.article}
  dangerouslySetInnerHTML={{
    __html: blog.body,
  }}
/>
  ```

## Tailwindへの移行検討
1. `@Tailwindcss/typography`プラグインを使用する方法
2. `global.css`と`tailewind.config.ts`で自分でスタイルを定義する方法

## 結論
tailwindとは相性が悪いとわかったので、このスタイルのみ`SCSS`での運用とする

### notion
[ブログ本文のTailwindへの移行検討](https://www.notion.so/dangerouslySetInnerHTML-tailwind-3159eee2c53e80da9af8e7b0b0c9acd4?source=copy_link)
