### PR TITLE
[Feat] headerとfooterの作成

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,9 @@ import "../src/styles/globals.css";
 
 const preview: Preview = {
   parameters: {
+    // 個別 Story で上書き可
+    layout: "fullscreen",
+
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.words": ["Commonlayout"],
-  "tailwindCSS.experimental.configFile": "tailwind.config.ts",
+  "tailwindCSS.experimental.configFile": "src/styles/globals.css",
   "editor.quickSuggestions": {
     "strings": "on"
   }

--- a/src/commons/layout/components/Footer/Footer.stories.tsx
+++ b/src/commons/layout/components/Footer/Footer.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import Footer from "./Footer";
+
+const meta = {
+  component: Footer,
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    pageList: ["Tags", "Service", "Profile"],
+  },
+};

--- a/src/commons/layout/components/Footer/Footer.tsx
+++ b/src/commons/layout/components/Footer/Footer.tsx
@@ -1,0 +1,19 @@
+import GlobalNav from "../GlobalNav/GlobalNav";
+
+type Props = {
+  pageList: string[];
+};
+
+const Footer = ({ pageList }: Props) => {
+  return (
+    <div className="bg-surface h-full px-8 py-24">
+      <div className="flex flex-col gap-4">
+        <GlobalNav pageList={pageList} />
+        <span className="-spacing-[0.5px] text-[24px]">MoneLogue</span>
+        <span className="text-sm">© 2024 MoneLogue</span>
+      </div>
+    </div>
+  );
+};
+
+export default Footer;

--- a/src/commons/layout/components/GlobalNav/GlobalNav.stories.tsx
+++ b/src/commons/layout/components/GlobalNav/GlobalNav.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import GlobalNav from "./GlobalNav";
+
+const meta = {
+  component: GlobalNav,
+} satisfies Meta<typeof GlobalNav>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    pageList: ["Tags", "Service", "Profile"],
+  },
+};

--- a/src/commons/layout/components/GlobalNav/GlobalNav.tsx
+++ b/src/commons/layout/components/GlobalNav/GlobalNav.tsx
@@ -1,0 +1,20 @@
+import { Search } from "lucide-react";
+
+type Props = {
+  pageList: string[];
+};
+
+const GlobalNav = ({ pageList }: Props) => {
+  return (
+    <div className="gap-md flex items-center">
+      {pageList.map((page) => (
+        <span key={page} className="text-secondary font-sans text-base">
+          {page}
+        </span>
+      ))}
+      <Search size={20} />
+    </div>
+  );
+};
+
+export default GlobalNav;

--- a/src/commons/layout/components/Header/Header.stories.tsx
+++ b/src/commons/layout/components/Header/Header.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import Header from "./Header";
+
+const meta = {
+  component: Header,
+} satisfies Meta<typeof Header>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    pageList: ["Tags", "Service", "Profile"],
+  },
+};

--- a/src/commons/layout/components/Header/Header.tsx
+++ b/src/commons/layout/components/Header/Header.tsx
@@ -1,0 +1,18 @@
+import GlobalNav from "../GlobalNav/GlobalNav";
+
+type Props = {
+  pageList: string[];
+};
+
+const Header = ({ pageList }: Props) => {
+  return (
+    <div className="bg-surface w-full px-8 py-3">
+      <div className="flex justify-between">
+        <span className="text-xl">MoneLogue</span>
+        <GlobalNav pageList={pageList} />
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    ".storybook/**/*.ts",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],


### PR DESCRIPTION
### デザイン
上から
- `Header`
- `Footer`
- `GlobalNav`
<img width="694" height="267" alt="image" src="https://github.com/user-attachments/assets/a8be8bc7-8e84-4a43-8046-0e58b3099880" />


### 備考
- [ ] fontを読み込んでいないので、一致していません
- [ ] `space`, `gap`などの数値を不必要にTokenで定義しているので、後に削除する

